### PR TITLE
Fix check if it is safe to return the same instance of AbstractAggregati...

### DIFF
--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractAggregatingFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/AbstractAggregatingFilter.java
@@ -64,7 +64,7 @@ public abstract class AbstractAggregatingFilter
             //            }
         }
 
-        if ( getFilters().equals( childFilters ) )
+        if ( filtersEqual( childFilters ) )
         {
             return this;
         }
@@ -123,7 +123,16 @@ public abstract class AbstractAggregatingFilter
         {
             //            if ( orderMatters )
             //            {
-            return filters.equals( otherFilters );
+            if ( otherFilters instanceof List )
+            {
+                return filters.equals( otherFilters );
+            }
+            else
+            {
+                List<ProjectRelationshipFilter> otherFiltersList = 
+                        new ArrayList<ProjectRelationshipFilter>( otherFilters );
+                return filters.equals( otherFiltersList );
+            }
             //            }
             //            else
             //            {


### PR DESCRIPTION
...ngFilter as child filter

The bug was introduced by me in 6b45232d8eb97af9b60a8e76718082fe8dbf7d0c