### PR TITLE
Fix ExcludingFilter

### DIFF
--- a/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ExcludingFilter.java
+++ b/relationships-api/src/main/java/org/commonjava/maven/atlas/graph/filter/ExcludingFilter.java
@@ -35,13 +35,21 @@ public class ExcludingFilter
     {
         final ProjectVersionRef target = rel.getTarget()
                                             .asProjectVersionRef();
-        return !excludedSubgraphs.contains( target );
+        return !excludedSubgraphs.contains( target ) && filter.accept( rel );
     }
 
     @Override
     public ProjectRelationshipFilter getChildFilter( final ProjectRelationship<?> parent )
     {
-        return this;
+        ProjectRelationshipFilter childfilter = filter.getChildFilter( parent );
+        if ( childfilter == filter )
+        {
+            return this;
+        }
+        else
+        {
+            return new ExcludingFilter( excludedSubgraphs, childfilter );
+        }
     }
 
     @Override


### PR DESCRIPTION
It did not use the embedded filter and accepted everything except tho artifacts
listed in the excludedSubgraphs.

Also getChildFilter returned the same instance all the time no matter if the
childFilter of the embedded filter changed or not.